### PR TITLE
Change NOT_IMPLEMENTED macro for boost compatibility

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -39,7 +39,7 @@ private:\
 
 // A simple macro to mark codes that are not implemented, so that when the code
 // is executed we will see a fatal log.
-#define NOT_IMPLEMENTED LOG(FATAL) << "Not Implemented Yet"
+#define NOT_IMPLMENTED_YET LOG(FATAL) << "Not Implemented Yet"
 
 namespace caffe {
 

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -66,7 +66,7 @@ class ArgMaxLayer : public Layer<Dtype> {
   /// @brief Not implemented (non-differentiable function)
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
-    NOT_IMPLEMENTED;
+    NOT_IMPLMENTED_YET;
   }
   bool out_max_val_;
   size_t top_k_;

--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -77,7 +77,7 @@ class AccuracyLayer : public Layer<Dtype> {
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
     for (int i = 0; i < propagate_down.size(); ++i) {
-      if (propagate_down[i]) { NOT_IMPLEMENTED; }
+      if (propagate_down[i]) { NOT_IMPLMENTED_YET; }
     }
   }
 

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -658,7 +658,7 @@ class ThresholdLayer : public NeuronLayer<Dtype> {
   /// @brief Not implemented (non-differentiable function)
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
-    NOT_IMPLEMENTED;
+    NOT_IMPLMENTED_YET;
   }
 
   Dtype threshold_;

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -106,8 +106,8 @@ void Blob<Dtype>::ShareDiff(const Blob& other) {
 // The "update" method is used for parameter blobs in a Net, which are stored
 // as Blob<float> or Blob<double> -- hence we do not define it for
 // Blob<int> or Blob<unsigned int>.
-template <> void Blob<unsigned int>::Update() { NOT_IMPLEMENTED; }
-template <> void Blob<int>::Update() { NOT_IMPLEMENTED; }
+template <> void Blob<unsigned int>::Update() { NOT_IMPLMENTED_YET; }
+template <> void Blob<int>::Update() { NOT_IMPLMENTED_YET; }
 
 template <typename Dtype>
 void Blob<Dtype>::Update() {
@@ -136,12 +136,12 @@ void Blob<Dtype>::Update() {
 }
 
 template <> unsigned int Blob<unsigned int>::asum_data() const {
-  NOT_IMPLEMENTED;
+  NOT_IMPLMENTED_YET;
   return 0;
 }
 
 template <> int Blob<int>::asum_data() const {
-  NOT_IMPLEMENTED;
+  NOT_IMPLMENTED_YET;
   return 0;
 }
 
@@ -171,12 +171,12 @@ Dtype Blob<Dtype>::asum_data() const {
 }
 
 template <> unsigned int Blob<unsigned int>::asum_diff() const {
-  NOT_IMPLEMENTED;
+  NOT_IMPLMENTED_YET;
   return 0;
 }
 
 template <> int Blob<int>::asum_diff() const {
-  NOT_IMPLEMENTED;
+  NOT_IMPLMENTED_YET;
   return 0;
 }
 

--- a/src/caffe/layers/pooling_layer.cpp
+++ b/src/caffe/layers/pooling_layer.cpp
@@ -200,7 +200,7 @@ void PoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     }
     break;
   case PoolingParameter_PoolMethod_STOCHASTIC:
-    NOT_IMPLEMENTED;
+    NOT_IMPLMENTED_YET;
     break;
   default:
     LOG(FATAL) << "Unknown pooling method.";
@@ -280,7 +280,7 @@ void PoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     }
     break;
   case PoolingParameter_PoolMethod_STOCHASTIC:
-    NOT_IMPLEMENTED;
+    NOT_IMPLMENTED_YET;
     break;
   default:
     LOG(FATAL) << "Unknown pooling method.";


### PR DESCRIPTION
Changed `NOT_IMPLEMENTED` to `NOT_IMPLEMENTED_YET` in the following files:
 /include/caffe/
- common.hpp
- common_layers.hpp
- loss_layers.hpp
- neuron_layers.hpp

/src/caffe/
- blob.cpp

/src/caffe/layers
- pooling_layer.cpp

This fixes the issue where boost and caffe both have macros named NOT_IMPLEMENTED, which caused compile errors.

This information is documented in the [ClarityEco wiki](https://github.com/clarityinc/clarityeco/wiki/DjiNN-&-Tonic#troubleshooting)
